### PR TITLE
Fix darwin build

### DIFF
--- a/src/util.cxx
+++ b/src/util.cxx
@@ -218,7 +218,12 @@ void pqxx::internal::wait_for(unsigned int microseconds)
   // MinGW still does not have a functioning <thread> header.  Work around this
   // using select().
   // Not worth optimising for though -- they'll have to fix it at some point.
+#if defined(OS_DARWIN)
+  timeval tv{microseconds / 1'000'000u, static_cast<__darwin_suseconds_t>(microseconds) % 1'000'000u};
+#else
   timeval tv{microseconds / 1'000'000u, microseconds % 1'000'000u};
+#endif
   select(0, nullptr, nullptr, nullptr, &tv);
+
 #endif
 }


### PR DESCRIPTION
` /build/contrib/libpqxx/src/util.cxx:221:41: error: non-constant-expression cannot be narrowed from type 'unsigned int' to '__darwin_suseconds_t' (aka 'int') in initializer list [-Wc++11-narrowing]
Jun 01 12:15:16   timeval tv{microseconds / 1'000'000u, microseconds % 1'000'000u};

Jun 01 12:15:16                                         ^~~~~~~~~~~~~~~~~~~~~~~~~
Jun 01 12:15:16 /build/contrib/libpqxx/src/util.cxx:221:41: note: insert an explicit cast to silence this issue
Jun 01 12:15:16   timeval tv{microseconds / 1'000'000u, microseconds % 1'000'000u};

Jun 01 12:15:16                                                               ^~~~~~~~~~~~~~~~~~~~~~~~~
Jun 01 12:15:16                                         static_cast<__darwin_suseconds_t>( )
Jun 01 12:15:16 1 error generated.`