### PR TITLE
Make global initializers jemalloc compatible

### DIFF
--- a/src/strconv.cxx
+++ b/src/strconv.cxx
@@ -236,7 +236,12 @@ std::string demangle_type_name(char const raw[])
   constexpr char *demangled{nullptr};
 #endif
   std::string const name{(demangled == nullptr) ? raw : demangled};
-  std::free(demangled);
+  // Do not try to call free(nullptr), even though it safe in general, this can
+  // be crucial for jemalloc when this code will be called from global
+  // variables initializations, since jemalloc() initializes itself only on
+  // malloc() not on free().
+  if (demangled)
+    std::free(demangled);
   return name;
 }
 


### PR DESCRIPTION
Before this patch demangle_type_name() can call free() w/o preceding
malloc(), but jemalloc tries to initialize itself only on malloc(), but
not on free(), and so it will fail with the following assertion, under osx:

    <jemalloc>: ./contrib/jemalloc/include/jemalloc/internal/tsd_generic.h:145: Failed assertion: "tsd_booted"

Upstream PR: https://github.com/jtv/libpqxx/pull/508