### PR TITLE
fix mem leak

### DIFF
--- a/src/connection.cxx
+++ b/src/connection.cxx
@@ -196,8 +196,18 @@ pqxx::result pqxx::connection::make_result(
     else
       throw broken_connection{"Lost connection to the database server."};
   }
-  auto const r{pqxx::internal::gate::result_creation::create(
-    pgr, query, internal::enc_group(encoding_id()))};
+  internal::encoding_group enc;
+  try
+  {
+    enc = internal::enc_group(encoding_id());
+  }
+  catch (std::exception const &)
+  {
+    // Don't let the PGresult leak. Useful in network partition.
+    internal::clear_result(pgr);
+    throw;
+  }
+  auto const r{pqxx::internal::gate::result_creation::create(pgr, query, enc)};
   pqxx::internal::gate::result_creation{r}.check_status(desc);
   return r;
 }


### PR DESCRIPTION
related to https://github.com/ClickHouse/ClickHouse/issues/56627. In this case, pg dict gets updated regularly. When connection becomes unavailable, pgresult would get leaked. There was also a fix in the original repo.  