### PR TITLE
handle boolean arrays from Postgresql by mapping t=1 and f=0

### DIFF
--- a/src/strconv.cxx
+++ b/src/strconv.cxx
@@ -439,6 +439,14 @@ template<typename T>
     for (; i < std::size(text) and isdigit(data[i]); ++i)
       result = absorb_digit_negative(result, digit_to_number(data[i]));
   }
+  else if (initial == 't')
+  {
+    result = 1;
+  }
+  else if (initial == 'f')
+  {
+    result = 0;
+  }
   else
   {
     throw pqxx::conversion_error{


### PR DESCRIPTION
Both PostgreSQL and MaterializedPostgreSQL engines fail to parse boolean array fields from PostgreSQL.
A `COPY () TO STDOUT` output looks like this:
```
Alex    {40}    {t,t,t}
Alex    {40,55,23}      {t,t,t}
```

The schema is `String,Array(Int),Array(Boolean)`.

The error looks like is:
```
<Error> executeQuery: std::exception. Code: 1001, type: pqxx::conversion_error, e.what() = Could not convert string to t: 't'
```
My understanding is that handling these fail under the integer converter (based on the error location) and the string `t` returned by Postgres can't be transformed to something that `libpqxx` can digest as a boolean.

This PR interprets literal `t` and `f` as `1` and `0`.
I don't have a deep enough knowledge of `libpqxx` internals but my guess is that this is the place to add these handlers.